### PR TITLE
Add pdfmux to RAG Data Preparation Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ This is a community project, and **we welcome contributions from everyone**! If 
 | CocoIndex | ETL framework to build fresh index | [Website](https://cocoindex.io/) | [Github](https://github.com/cocoindex-io/cocoindex) | [![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex) | 1h ago   |
 | Gitana.io | Content platform for editorial approval and scheduled deployment of trained data sets to RAG vector DBs | [Website](https://gitana.io/) | - | - | - |
 | Chonkie   | No-nonsense, lightweight and fast RAG chunking library | [Website](https://chonkie.ai/) | [GitHub](https://github.com/chonkie-inc/chonkie) | [![GitHub stars](https://img.shields.io/github/stars/chonkie-inc/chonkie?style=social)](https://github.com/chonkie-inc/chonkie) | 1h ago |
+| pdfmux | PDF-to-Markdown extraction with per-page confidence scoring and self-healing fallback. Built-in MCP server, LangChain + LlamaIndex loaders. #2 on opendataloader-bench. | [Website](https://pdfmux.com) | [GitHub](https://github.com/NameetP/pdfmux) | [![GitHub stars](https://img.shields.io/github/stars/NameetP/pdfmux?style=social)](https://github.com/NameetP/pdfmux) | 1d ago |
 
 ## RAG Projects
 


### PR DESCRIPTION
Adding **pdfmux** to **RAG Data Preparation Frameworks**. It's a Python library that converts PDFs to Markdown for RAG ingestion, with one unique behavior: it scores every page's extraction confidence and automatically re-extracts low-confidence pages with a fallback engine — catching the silent-failure mode that quietly breaks RAG retrieval quality. Native LangChain (`PdfmuxLoader`) and LlamaIndex (`PdfmuxReader`) integrations, plus a built-in MCP server. Ranks #2 on the [opendataloader-bench](https://github.com/opendatalab/opendataloader-bench) reading-order benchmark (0.900 across 200 PDFs). MIT licensed. `pip install pdfmux`.