### PR TITLE
Add FastRAG to RAG projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 | hydrot                          | A production-ready Retrieval-Augmented Generation (RAG) system designed for enterprise documentation, with first-class support for markdown content. Built with a microservices architecture for horizontal scaling and flexibility. | - | [Github](https://github.com/rjxby/hydrot) | ![Github stars](https://img.shields.io/github/stars/rjxby/hydrot?style=social)|-|
 | Tensorlake                         | Document parsing for citable, traceable RAG systems. Extracts text, tables, and images while maintaining complex layouts, attaching bounding box coordinates, and supporting structured output | [Website](https://www.tensorlake.ai/) | [Github](https://github.com/tensorlakeai) | ![Github stars](https://img.shields.io/github/stars/tensorlakeai/indexify?style=social) | 2d ago|
 | KV Cache Store                       | Hosted KV-cache artifact registry plus open-source Rust CLI. Precompute attention states once, verify bit-exact, and reuse across RAG and long-context prompts to cut prefill cost and latency. | [Website](https://kvcachestore.com) | [GitHub](https://github.com/kvcachestore/kvcdn) | ![GitHub stars](https://img.shields.io/github/stars/kvcachestore/kvcdn?style=social) | - |
+| FastRAG | Starter kit for shipping RAG apps fast with Next.js, Pinecone & LangChain pre-configured. | [Website](https://www.fastrag.live/) | Closed-source | - | - |
 
 ## RAG Resources and Sites
 


### PR DESCRIPTION
Adds FastRAG (https://www.fastrag.live/) — a starter kit for shipping RAG apps quickly, with Next.js, Pinecone, and LangChain pre-configured out of the box. It handles PDF/URL ingestion, chunking, and vector storage so developers can skip the typical setup work.

Note: FastRAG is currently closed-source, so I've marked the Github/Stars/Last activity columns as "-" rather than leaving them blank. Happy to adjust the format if maintainers prefer something else.